### PR TITLE
Added qt web engine as required package

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Install the following packages using apt (don't use pip etc.):
     * gir1.2-appstream-1.0
     * python3-aptdaemon
     * python3-apt
+    * python3-pyqt5.qtwebengine
     
 ## Usage
     * Make superx-store executable: chmod +x ./superx-store


### PR DESCRIPTION
KDE Neon vanilla doesnt seem to come installed with it. Had to install the package manually to make things work. 